### PR TITLE
Nullable warnings should be considered errors

### DIFF
--- a/src/InsertionsClient.Console/InsertionsClient.Console.csproj
+++ b/src/InsertionsClient.Console/InsertionsClient.Console.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Net.Insertions</RootNamespace>
-    <AssemblyName>InsertionsClient</AssemblyName>
+    <AssemblyName>InsertionsClient.Console</AssemblyName>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>

--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Net.Insertions</RootNamespace>
-    <AssemblyName>InsertionsClient</AssemblyName>
+    <AssemblyName>InsertionsClient.Core</AssemblyName>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>

--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Microsoft.Net.Insertions</RootNamespace>
+    <AssemblyName>InsertionsClient</AssemblyName>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We separated console app from the core api in this PR: https://github.com/bozturkMSFT/insertions-client/pull/36

Newly created `Core` project does not consider all nullable reference type issues as "errors" like previous project did.

This PR fixes it so that all the warnings will be treated as errors.