### PR TITLE
Publish nuget packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ steps:
   displayName: 'Test'
 - task: DotNetCoreCLI@2
   displayName: Pack
+  condition: eq(variables.PublishToFeed, true)
   inputs:
     command: pack
     packagesToPack: 'src/**/*.csproj'
@@ -31,17 +32,21 @@ steps:
     includesymbols: true
     includesource: true
     configuration: release
-- task: NuGetAuthenticate@0
-  displayName: 'NuGet Authenticate'
-- task: NuGetCommand@2
-  displayName: 'NuGet push'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-    publishVstsFeed: 'public/dotnet-eng'
-    allowPackageConflicts: true
 - task: PublishBuildArtifacts@1
+  condition: eq(variables.PublishToFeed, true)
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'NugetArtifacts' 
     publishLocation: 'Container'
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - task: NuGetAuthenticate@0
+    condition: eq(variables.PublishToFeed, true)
+    displayName: 'NuGet Authenticate'
+  - task: NuGetCommand@2
+    displayName: 'NuGet push'
+    condition: eq(variables.PublishToFeed, true)
+    inputs:
+      command: push
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+      publishVstsFeed: 'public/dotnet-eng'
+      allowPackageConflicts: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ steps:
     packTimezone: 'utc'
     includesymbols: true
     includesource: true
+    configuration: release
 - task: NuGetAuthenticate@0
   displayName: 'NuGet Authenticate'
 - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+variables:
+  Major: '1'
+  Minor: '0'
+  Patch: '0'
 
 trigger:
 - master
@@ -13,8 +13,34 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: 'build'
-  displayName: 'build'
+  displayName: 'Build'
 - task: DotNetCoreCLI@2
   inputs:
     command: 'test'
-  displayName: 'run tests'
+  displayName: 'Test'
+- task: DotNetCoreCLI@2
+  displayName: Pack
+  inputs:
+    command: pack
+    packagesToPack: 'src/**/*.csproj'
+    versioningScheme: byPrereleaseNumber
+    majorVersion: '$(Major)'
+    minorVersion: '$(Minor)'
+    patchVersion: '$(Patch)'
+    packTimezone: 'utc'
+    includesymbols: true
+    includesource: true
+- task: NuGetAuthenticate@0
+  displayName: 'NuGet Authenticate'
+- task: NuGetCommand@2
+  displayName: 'NuGet push'
+  inputs:
+    command: push
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+    publishVstsFeed: 'public/dotnet-eng'
+    allowPackageConflicts: true
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: 'NugetArtifacts' 
+    publishLocation: 'Container'

--- a/src/InsertionsClient.Console/Common/Logging/InsertionsConsoleTraceListener.cs
+++ b/src/InsertionsClient.Console/Common/Logging/InsertionsConsoleTraceListener.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.Net.Insertions.Common.Logging
+namespace Microsoft.DotNet.InsertionsClient.Common.Logging
 {
     internal sealed class InsertionsConsoleTraceListener : ConsoleTraceListener
     {

--- a/src/InsertionsClient.Console/Common/Logging/InsertionsTextWriterTraceListener.cs
+++ b/src/InsertionsClient.Console/Common/Logging/InsertionsTextWriterTraceListener.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.Net.Insertions.Common.Logging
+namespace Microsoft.DotNet.InsertionsClient.Common.Logging
 {
     internal sealed class InsertionsTextWriterTraceListener : TextWriterTraceListener
     {

--- a/src/InsertionsClient.Console/Common/Logging/Utilities.cs
+++ b/src/InsertionsClient.Console/Common/Logging/Utilities.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Text;
 
-namespace Microsoft.Net.Insertions.Common.Logging
+namespace Microsoft.DotNet.InsertionsClient.Common.Logging
 {
     internal static class Utilities
     {

--- a/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Net.Insertions.ConsoleApp
+namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
 {
     internal static class InputLoading
     {

--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.Common.Constants;
-using Microsoft.Net.Insertions.Common.Logging;
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.Common.Constants;
+using Microsoft.DotNet.InsertionsClient.Common.Logging;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -18,7 +18,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 
 [assembly: InternalsVisibleTo("InsertionsClient.Console.Test")]
-namespace Microsoft.Net.Insertions.ConsoleApp
+namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
 {
     internal class Program
     {

--- a/src/InsertionsClient.Console/InsertionsClient.Console.csproj
+++ b/src/InsertionsClient.Console/InsertionsClient.Console.csproj
@@ -8,6 +8,8 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>InsertionsClient</ToolCommandName>
     <Authors>Microsoft, DotNet</Authors>
     <Company>Microsoft</Company>
     <Product>Microsoft.Dotnet.InsertionsClient.Console</Product>
@@ -18,7 +20,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\InsertionsClient.Core\InsertionsClient.Core.csproj" />

--- a/src/InsertionsClient.Console/InsertionsClient.Console.csproj
+++ b/src/InsertionsClient.Console/InsertionsClient.Console.csproj
@@ -3,10 +3,20 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Microsoft.Net.Insertions</RootNamespace>
-    <AssemblyName>InsertionsClient.Console</AssemblyName>
+    <RootNamespace>Microsoft.DotNet.InsertionsClient</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.InsertionsClient.Console</AssemblyName>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    
+    <Authors>Microsoft, DotNet</Authors>
+    <Company>Microsoft</Company>
+    <Product>Microsoft.Dotnet.InsertionsClient.Console</Product>
+    <Description>Console application for inserting .NET Core SDK into Visual Studio.</Description>
+    <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/dotnet/insertions-client</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/dotnet/insertions-client</RepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
 

--- a/src/InsertionsClient.Core/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient.Core/Api/DefaultConfigUpdater.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Common.Constants;
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Common.Constants;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -12,7 +12,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 
-namespace Microsoft.Net.Insertions.Api
+namespace Microsoft.DotNet.InsertionsClient.Api
 {
     /// <summary>
     /// Manages loading and updating &quot;default.config&quot; file and &quot;.packageconfig&quot; files listed in it.

--- a/src/InsertionsClient.Core/Api/IInsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApi.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 [assembly: InternalsVisibleTo("InsertionsClient.Core.Test")]
-namespace Microsoft.Net.Insertions.Api
+namespace Microsoft.DotNet.InsertionsClient.Api
 {
     /// <summary>
     /// Defines features to manage default.config insertions from manifest.json.

--- a/src/InsertionsClient.Core/Api/IInsertionApiFactory.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApiFactory.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Microsoft.Net.Insertions.Api
+namespace Microsoft.DotNet.InsertionsClient.Api
 {
     /// <summary>
     /// Factory of <see cref="IInsertionApi"/> instances.

--- a/src/InsertionsClient.Core/Api/Props/Models/PayloadPath.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/PayloadPath.cs
@@ -2,7 +2,7 @@
 
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Net.Insertions.Api.Props.Models
+namespace Microsoft.DotNet.InsertionsClient.Api.Props.Models
 {
     /// <summary>
     /// Represents a payload defined in the swr file.

--- a/src/InsertionsClient.Core/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/PropsFile.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 
-namespace Microsoft.Net.Insertions.Props.Models
+namespace Microsoft.DotNet.InsertionsClient.Props.Models
 {
     /// <summary>
     /// This type represents a props file that contains the variables

--- a/src/InsertionsClient.Core/Api/Props/Models/PropsFileVariableReference.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/PropsFileVariableReference.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.Net.Insertions.Props.Models
+namespace Microsoft.DotNet.InsertionsClient.Props.Models
 {
     /// <summary>
     /// Represents a reference to a variable defined in a props file

--- a/src/InsertionsClient.Core/Api/Props/Models/PropsUpdateResults.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/PropsUpdateResults.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System.Collections.Generic;
 
-namespace Microsoft.Net.Insertions.Props.Models
+namespace Microsoft.DotNet.InsertionsClient.Props.Models
 {
     /// <summary>
     /// Represents the result of a PropsFile update operation

--- a/src/InsertionsClient.Core/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/SwrFile.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Net.Insertions.Api.Props.Models
+namespace Microsoft.DotNet.InsertionsClient.Api.Props.Models
 {
     /// <summary>
     /// Represents an SWR file in a VS repo local working directory.

--- a/src/InsertionsClient.Core/Api/Props/PropsFileUpdater.cs
+++ b/src/InsertionsClient.Core/Api/Props/PropsFileUpdater.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
-namespace Microsoft.Net.Insertions.Api.Providers
+namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 {
     /// <summary>
     /// Used to find given variables in props files under a given directory and updates their values.

--- a/src/InsertionsClient.Core/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient.Core/Api/Props/PropsVariableDeducer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Props.Models;
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Api.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
@@ -20,7 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
-namespace Microsoft.Net.Insertions.Api
+namespace Microsoft.DotNet.InsertionsClient.Api
 {
     /// <summary>
     /// Deduces the values of given props file variables by matching:

--- a/src/InsertionsClient.Core/Api/Props/SwrFileReader.cs
+++ b/src/InsertionsClient.Core/Api/Props/SwrFileReader.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Api.Props.Models;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace Microsoft.Net.Insertions.Api
+namespace Microsoft.DotNet.InsertionsClient.Api
 {
     /// <summary>
     /// Finds and loads .swr files in a given directory.

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Props.Models;
-using Microsoft.Net.Insertions.Common.Constants;
-using Microsoft.Net.Insertions.Common.Json;
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Models.Extensions;
-using Microsoft.Net.Insertions.Props.Models;
-using Microsoft.Net.Insertions.Telemetry;
+using Microsoft.DotNet.InsertionsClient.Api.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Common.Constants;
+using Microsoft.DotNet.InsertionsClient.Common.Json;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Models.Extensions;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Telemetry;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -19,7 +19,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Net.Insertions.Api.Providers
+namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 {
     /// <summary>
     /// <see cref="IInsertionApi"/> provider relying on <see cref="IDefaultConfigApi"/> instances to update NuGet versions.

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApiFactory.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApiFactory.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Microsoft.Net.Insertions.Api.Providers
+namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 {
     public sealed class InsertionApiFactory : IInsertionApiFactory
     {

--- a/src/InsertionsClient.Core/Common/Constants/InsertionConstants.cs
+++ b/src/InsertionsClient.Core/Common/Constants/InsertionConstants.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
-namespace Microsoft.Net.Insertions.Common.Constants
+namespace Microsoft.DotNet.InsertionsClient.Common.Constants
 {
     public static class InsertionConstants
     {

--- a/src/InsertionsClient.Core/Common/Json/Serializer.cs
+++ b/src/InsertionsClient.Core/Common/Json/Serializer.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
 
-namespace Microsoft.Net.Insertions.Common.Json
+namespace Microsoft.DotNet.InsertionsClient.Common.Json
 {
     /// <summary>
     /// Contains JSon serializing utilities.

--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -1,11 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RootNamespace>Microsoft.Net.Insertions</RootNamespace>
-    <AssemblyName>InsertionsClient.Core</AssemblyName>
+    <RootNamespace>Microsoft.DotNet.InsertionsClient</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.InsertionsClient.Core</AssemblyName>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    
+    <Authors>Microsoft, DotNet</Authors>
+    <Company>Microsoft</Company>
+    <Product>Microsoft.Dotnet.InsertionsClient.Core</Product>
+    <Description>Core library for inserting .NET Core SDK into Visual Studio.</Description>
+    <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/dotnet/insertions-client</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/dotnet/insertions-client</RepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/InsertionsClient.Core/Models/Asset.cs
+++ b/src/InsertionsClient.Core/Models/Asset.cs
@@ -2,7 +2,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary>
     /// Describes individual build assets.

--- a/src/InsertionsClient.Core/Models/AssetEqualityComparer.cs
+++ b/src/InsertionsClient.Core/Models/AssetEqualityComparer.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     internal sealed class AssetEqualityComparer : IEqualityComparer<Asset>
     {

--- a/src/InsertionsClient.Core/Models/Build.cs
+++ b/src/InsertionsClient.Core/Models/Build.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary>
     /// Defines a manifest.json build.

--- a/src/InsertionsClient.Core/Models/Extensions/ManifestExtensions.cs
+++ b/src/InsertionsClient.Core/Models/Extensions/ManifestExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.Net.Insertions.Models.Extensions
+namespace Microsoft.DotNet.InsertionsClient.Models.Extensions
 {
     internal static class ManifestExtensions
     {

--- a/src/InsertionsClient.Core/Models/Extensions/UpdateExtensions.cs
+++ b/src/InsertionsClient.Core/Models/Extensions/UpdateExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.Net.Insertions.Models.Extensions
+namespace Microsoft.DotNet.InsertionsClient.Models.Extensions
 {
     internal static class UpdateExtensions
     {

--- a/src/InsertionsClient.Core/Models/FileSaveResult.cs
+++ b/src/InsertionsClient.Core/Models/FileSaveResult.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary> Stores the result of a file save operation.
     public struct FileSaveResult : IEquatable<FileSaveResult>

--- a/src/InsertionsClient.Core/Models/Manifest.cs
+++ b/src/InsertionsClient.Core/Models/Manifest.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary>
     /// Model for manifest.json Builds collection.

--- a/src/InsertionsClient.Core/Models/PackageUpdateResult.cs
+++ b/src/InsertionsClient.Core/Models/PackageUpdateResult.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary>
     /// Stores the result of a package version update operation

--- a/src/InsertionsClient.Core/Models/Update.cs
+++ b/src/InsertionsClient.Core/Models/Update.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     internal enum Update
     {

--- a/src/InsertionsClient.Core/Models/UpdateResults.cs
+++ b/src/InsertionsClient.Core/Models/UpdateResults.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
-namespace Microsoft.Net.Insertions.Models
+namespace Microsoft.DotNet.InsertionsClient.Models
 {
     /// <summary>
     /// Describes the response to <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> calls.

--- a/src/InsertionsClient.Core/Telemetry/DescriptiveStatistics.cs
+++ b/src/InsertionsClient.Core/Telemetry/DescriptiveStatistics.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Telemetry.Models;
+using Microsoft.DotNet.InsertionsClient.Telemetry.Models;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Microsoft.Net.Insertions.Telemetry
+namespace Microsoft.DotNet.InsertionsClient.Telemetry
 {
     internal sealed class DescriptiveStatistics
     {

--- a/src/InsertionsClient.Core/Telemetry/MeasurementsSession.cs
+++ b/src/InsertionsClient.Core/Telemetry/MeasurementsSession.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Telemetry.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Telemetry.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Net.Insertions.Telemetry
+namespace Microsoft.DotNet.InsertionsClient.Telemetry
 {
     internal sealed class MeasurementsSession
     {

--- a/src/InsertionsClient.Core/Telemetry/Models/Measurement.cs
+++ b/src/InsertionsClient.Core/Telemetry/Models/Measurement.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System;
 
-namespace Microsoft.Net.Insertions.Telemetry.Models
+namespace Microsoft.DotNet.InsertionsClient.Telemetry.Models
 {
     internal sealed class Measurement
     {

--- a/tests/InsertionsClient.Console.Test/InputParsingTests.cs
+++ b/tests/InsertionsClient.Console.Test/InputParsingTests.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.ConsoleApp;
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.ConsoleApp;
+using Microsoft.DotNet.InsertionsClient.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;

--- a/tests/InsertionsClient.Core.Test/DefaultConfigUpdaterTest.cs
+++ b/tests/InsertionsClient.Core.Test/DefaultConfigUpdaterTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;

--- a/tests/InsertionsClient.Core.Test/ManifestTest.cs
+++ b/tests/InsertionsClient.Core.Test/ManifestTest.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.Common.Json;
-using Microsoft.Net.Insertions.Models;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.Common.Json;
+using Microsoft.DotNet.InsertionsClient.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;

--- a/tests/InsertionsClient.Core.Test/PropsTests.cs
+++ b/tests/InsertionsClient.Core.Test/PropsTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Api.Props.Models;
-using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Api.Props.Models;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.DotNet.InsertionsClient.Props.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;

--- a/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
+++ b/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.Common.Constants;
-using Microsoft.Net.Insertions.Models;
+﻿using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.Common.Constants;
+using Microsoft.DotNet.InsertionsClient.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Delivers #3 

- Renamed namespaces to better align with existing dotnet tools.
- Updated `azure-pipelines.yml` to pack and publish packages during internal builds. Public builds can generate packages if triggered manually. PR builds doesn't produce packages.

