### PR TITLE
Update allowlist to be an actual one

### DIFF
--- a/tests/InsertionsClient.Core.Test/Assets/whitelist.txt
+++ b/tests/InsertionsClient.Core.Test/Assets/whitelist.txt
@@ -1,7 +1,4 @@
-^VS\.Redist\.Common\.AspNetCore\.SharedFramework\.(x86|x64)\.[0-9]+\.[0-9]+$
-^VS\.Redist\.Common\.Net\.Core\.SDK\.MSBuildExtensions$
-^VS\.Redist\.Common\.NetCore\.AppHostPack\.(x86|x64).*\.[0-9]+\.[0-9]+$
-^VS\.Redist\.Common\.NetCore\.SharedFramework\.(x86|x64)\.[0-9]+\.[0-9]+$
-^VS\.Redist\.Common\.NetCore\.SharedHost\.(x86|x64)\.[0-9]+\.[0-9]+$
-^VS\.Redist\.Common\.NetCore\.Toolset\.(x86|x64)$
-^VS\.Redist\.Common\.NetCore\.Templates\.x64\.2\.[0-9]+$
+^VS\.Redist\.Common\.AspNetCore\.
+^VS\.Redist\.Common\.Net\.Core\.SDK\.MSBuildExtensions
+^VS\.Redist\.Common\.NetCore\.
+^VS\.Redist\.Common\.WindowsDesktop\.


### PR DESCRIPTION
This is tested against an actual insertion. We don't need the match to be super precise. And the wildcards of everything starts with `VS\.Redist\.Common\.NetCore\` make sense since we do control the insertion with everything .net core