### PR TITLE
Don't write xml declaration into props file

### DIFF
--- a/src/InsertionsClient.Core/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient.Core/Api/Props/Models/PropsFile.cs
@@ -4,6 +4,7 @@ using Microsoft.Net.Insertions.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
@@ -45,6 +46,16 @@ namespace Microsoft.Net.Insertions.Props.Models
         private XDocument? _xDocument { get; set; }
 
         private bool _isLoaded => _xDocument != null;
+
+        /// <summary>
+        /// Settings to make sure saved xml has correct the formatting.
+        /// </summary>
+        private static readonly XmlWriterSettings _xmlWriteSettings = new XmlWriterSettings()
+        {
+            OmitXmlDeclaration = true,
+            Indent = true,
+            Encoding = Encoding.ASCII
+        };
 
         /// <summary>
         /// Attempts to find given variable in the file. Changes the value if found.
@@ -114,7 +125,8 @@ namespace Microsoft.Net.Insertions.Props.Models
 
             try
             {
-                _xDocument!.Save(Path);
+                using XmlWriter writer = XmlWriter.Create(Path, _xmlWriteSettings);
+                _xDocument!.Save(writer);
                 return new FileSaveResult(Path);
             }
             catch (Exception e)

--- a/tests/InsertionsClient.Console.Test/InputParsingTests.cs
+++ b/tests/InsertionsClient.Console.Test/InputParsingTests.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Net.Insertions.Api;
 using Microsoft.Net.Insertions.Api.Providers;
-using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.ConsoleApp;
 using Microsoft.Net.Insertions.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/InsertionsClient.Core.Test/Assets/dotNetCoreVersions.props
+++ b/tests/InsertionsClient.Core.Test/Assets/dotNetCoreVersions.props
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(_NTBINDIR)\SetupPackages\Group\ddswixgroup.props" />
   <PropertyGroup>
     <PackagePreprocessorDefinitions>


### PR DESCRIPTION
Fixes #10 

By default, `XDocument` adds xml declaration when saving the file to disk, which is not something we want in props files.

This PR makes sure no declaration is added to the file.