### PR TITLE
Main should return nonzero in case of error

### DIFF
--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
         private static string LogFile { get; }
 
         [STAThread]
-        private static void Main(string[] args)
+        private static int Main(string[] args)
         {
             ShowStartOrEndMessage($"Running {ProgramName.Value}");
 
@@ -144,6 +144,8 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             ShowResults(results);
 
             Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
+            
+            return results.Outcome ? 0 : 1;
         }
 
         private static void ShowResults(UpdateResults results)

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -138,6 +138,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
                     Trace.WriteLine("default.config and .packageconfig file updates were skipped, because " +
                         "there was an issue updating .props files.");
                     results.FileSaveResults = new FileSaveResult[0];
+                    results.OutcomeDetails += "Failure in updating .props files.";
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Delivers work item: [#1147337](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1147337)

To propagate the errors in automation scenarios, console app should return nonzero in case of a failure.

The changes make sure:
 - `main` returns 1 in case of an error
 - Failure in "updating the props files" fails the whole job even though "default.config" updates were successful.