### PR TITLE
Add support for multiple manifest files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,14 @@
 ## Input
 1. **-d:** Path to the default.config.  Example: 
     > _-d:c:\default.config_
-1. **-m:** Path to the manifest.json.  Example:
+1. **-m:** Path to the manifest.json file or to the containing directory.
+   
+   The following two examples use the same manifest file:
     > _-m:c:\files\manifest.json_
+    > _-m:c:\files\_
+
+   It is also possible to input multiple manifest files. In this case, the files will be processed in order. If the same package is updated from multiple manifest files, version number from the last specified manifest file will be used. To do this, use semicolon (;) to separate the paths as such:
+    > _m:c:\files\manifest.json;c:\just\folder\\;c:\another\fullpath\manifest.json_
 1. **-i:** Path to ignored packages file [**optional**]. Example: 
     > _-i:c:\files\ignore.txt_
 1. **-idut** Indicates that packages relevant to the .NET Dev UX team are ignored [**optional**].  If **-i:** is also set, the file specified with that option is used, superceding **-idut**.

--- a/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.DotNet.InsertionsClient.Common.Constants;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
                 Trace.WriteLine($"CMD line param. {cmdLineMessage} {argumentValue}");
                 return argumentValue;
             }
-             
+
             Trace.WriteLine(@"Specified value is not an integer. Default value of ""-1"" will be used.");
             return -1;
         }
@@ -61,6 +62,54 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             }
 
             return File.ReadAllLines(ignoredPackagesFile).ToImmutableHashSet();
+        }
+
+        /// <summary>
+        /// Parses the semicolon separated manifest path string into multiple file paths.
+        /// In the case that a path is pointing to a directory instead of a file, manifest file
+        /// is searched in that directory.
+        /// </summary>
+        /// <param name="manifestPaths">Semicolon separated String that contains all the paths.</param>
+        /// <param name="invalidPathCount">Number of paths that failed to resolve to a file on disk.</param>
+        /// <returns>A list of paths pointing to manifest files.</returns>
+        internal static List<string> LoadManifestPaths(string manifestPaths, out int invalidPathCount)
+        {
+            if(string.IsNullOrWhiteSpace(manifestPaths))
+            {
+                invalidPathCount = 0;
+                return new List<string>();
+            }
+
+            invalidPathCount = 0;
+            List<string> results = new List<string>();
+            string[] paths = manifestPaths.Split(';');
+
+            foreach (string path in paths)
+            {
+                if(string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
+                string pathToFile = path;
+
+                if (Directory.Exists(path))
+                {
+                    // Path appears to be a directory. Manifest should be inside.
+                    pathToFile = Path.Combine(path, InsertionConstants.ManifestFile);
+                }
+
+                if (File.Exists(pathToFile))
+                {
+                    results.Add(pathToFile);
+                    continue;
+                }
+
+                invalidPathCount++;
+                Trace.WriteLine($"The given path neither points to a manifest file nor to a directory that contains a manifest file: {path}");
+            }
+
+            return results;
         }
     }
 }

--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
 
             if(invalidManifestFileCount != 0)
             {
-                ShowErrorHelpAndExit($"Failed to find one or more manifest.json files specified in '{ManifestFile}'");
+                ShowErrorHelpAndExit($"Failed to find {invalidManifestFileCount.ToString()} manifest.json files specified in '{ManifestFile}'");
             }
 
             if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))

--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -120,8 +120,14 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
 
             IInsertionApiFactory apiFactory = new InsertionApiFactory();
             IInsertionApi api = apiFactory.Create(MaxWaitDuration, MaxDownloadDuration, MaxConcurrency);
+            List<string> manifestFiles = InputLoading.LoadManifestPaths(ManifestFile, out int invalidManifestFileCount);
             IEnumerable<Regex> whitelistedPackages = InputLoading.LoadWhitelistedPackages(WhitelistedPackagesFile);
             ImmutableHashSet<string> ignoredPackages = ImmutableHashSet<string>.Empty;
+
+            if(invalidManifestFileCount != 0)
+            {
+                ShowErrorHelpAndExit($"Failed to find one or more manifest.json files specified in '{ManifestFile}'");
+            }
 
             if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
             {
@@ -131,9 +137,9 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             {
                 ignoredPackages = InsertionConstants.DefaultDevUxTeamPackages;
             }
-
+            
             UpdateResults results = api.UpdateVersions(
-                    ManifestFile,
+                    manifestFiles,
                     DefaultConfigFile,
                     whitelistedPackages,
                     ignoredPackages,
@@ -144,7 +150,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             ShowResults(results);
 
             Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
-            
+
             return results.Outcome ? 0 : 1;
         }
 
@@ -228,8 +234,8 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             Trace.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
 
             Trace.WriteLine($"{Environment.NewLine}Options:");
-            Trace.WriteLine($"{SwitchDefaultConfig}   full path on disk to default.config to update");
-            Trace.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
+            Trace.WriteLine($"{SwitchDefaultConfig}   path on disk to default.config to update");
+            Trace.WriteLine($"{SwitchManifest}   path on disk to a manifest.json file or to the containing folder. Supports multiple entries separated by semicolons");
             Trace.WriteLine($"{SwitchWhitelistedPackages}   full path on disk to whitelisted packages file. Each line should contain a regex pattern that may match zero or more package ids [optional]");
             Trace.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
             Trace.WriteLine($"{SwitchPropsFilesRootDir}   directory to search for and update .props files [optional]");

--- a/src/InsertionsClient.Core/Api/ApiExtensions.cs
+++ b/src/InsertionsClient.Core/Api/ApiExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.DotNet.InsertionsClient.Models;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.InsertionsClient.Api
+{
+    public static class ApiExtensions
+    {
+        /// <summary>
+        /// Convenience method to call <see cref="IInsertionApi.UpdateVersions(IEnumerable{string}, string, IEnumerable{Regex}, ImmutableHashSet{string}?, string?, string?)"/>
+        /// with a single manifest file instead of a set of manifest files.
+        /// See the documentation of the related method for the detailed usage.
+        /// </summary>
+        public static UpdateResults UpdateVersions( this IInsertionApi api,
+            string manifestFile,
+            string defaultConfigFile,
+            IEnumerable<Regex> whitelistedPackages,
+            ImmutableHashSet<string>? packagesToIgnore,
+            string? accessToken,
+            string? propsFilesRootDirectory)
+        {
+            return api.UpdateVersions(
+                new[] { manifestFile },
+                defaultConfigFile,
+                whitelistedPackages,
+                packagesToIgnore,
+                accessToken,
+                propsFilesRootDirectory);
+        }
+    }
+}

--- a/src/InsertionsClient.Core/Api/ApiExtensions.cs
+++ b/src/InsertionsClient.Core/Api/ApiExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api
         /// with a single manifest file instead of a set of manifest files.
         /// See the documentation of the related method for the detailed usage.
         /// </summary>
-        public static UpdateResults UpdateVersions( this IInsertionApi api,
+        public static UpdateResults UpdateVersions(this IInsertionApi api,
             string manifestFile,
             string defaultConfigFile,
             IEnumerable<Regex> whitelistedPackages,

--- a/src/InsertionsClient.Core/Api/IInsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApi.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.
         /// </summary>
-        /// <param name="manifestFile">The paths to all the manifest.json files to be inserted.</param>
+        /// <param name="manifestFiles">The paths to all the manifest.json files to be inserted.</param>
         /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
         /// <param name="whitelistedPackages">Regex patterns matching with the packages that are allowed to be updated. If the set is empty,
         /// any package is allowed be updated unless specified in packagesToIgnore.</param>

--- a/src/InsertionsClient.Core/Api/IInsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApi.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.
         /// </summary>
-        /// <param name="manifestFile">Specified manifest.json.</param>
+        /// <param name="manifestFile">The paths to all the manifest.json files to be inserted.</param>
         /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
         /// <param name="whitelistedPackages">Regex patterns matching with the packages that are allowed to be updated. If the set is empty,
         /// any package is allowed be updated unless specified in packagesToIgnore.</param>
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api
         /// <param name="propsFilesRootDirectory">Directory that will be searched for props files.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
         UpdateResults UpdateVersions(
-            string manifestFile,
+            IEnumerable<string> manifestFiles,
             string defaultConfigFile,
             IEnumerable<Regex> whitelistedPackages,
             ImmutableHashSet<string>? packagesToIgnore,

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -265,7 +265,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
             string json = File.ReadAllText(manifestFile);
             if (string.IsNullOrWhiteSpace(json))
             {
-                Trace.WriteLine($"Failed to read JSon content from file {manifestFile}.");
+                Trace.WriteLine($"Failed to read JSON content from file {manifestFile}.");
                 return null;
             }
             try

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -46,27 +46,35 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
         #region IInsertionApi API
 
         public UpdateResults UpdateVersions(
-            string manifestFile,
+            IEnumerable<string> manifestFiles,
             string defaultConfigFile,
             IEnumerable<Regex> whitelistedPackages,
             ImmutableHashSet<string>? packagesToIgnore,
             string? accessToken = null,
             string? propsFilesRootDirectory = null)
         {
-            List<Asset> assets = null!;
+            List<Asset> assets = new List<Asset>();
             DefaultConfigUpdater configUpdater;
 
-            if (!TryValidateManifestFile(manifestFile, out string details)
-                || !TryExtractManifestAssets(manifestFile, out assets, out details)
-                || !TryLoadDefaultConfig(defaultConfigFile, out configUpdater, out details))
+            if (!TryLoadDefaultConfig(defaultConfigFile, out configUpdater, out string details))
             {
-                return new UpdateResults { OutcomeDetails = details };
+                return new UpdateResults { OutcomeDetails = details, IgnoredNuGets = packagesToIgnore };
+            }
+
+            foreach (var manifestFile in manifestFiles)
+            {
+                if (!TryValidateManifestFile(manifestFile, out details)
+                    || !TryExtractManifestAssets(manifestFile, assets, out details))
+                {
+                    return new UpdateResults { OutcomeDetails = details, IgnoredNuGets = packagesToIgnore };
+                }
             }
 
             UpdateResults results = new UpdateResults
             {
                 IgnoredNuGets = packagesToIgnore
             };
+
             Stopwatch overallRunStopWatch = Stopwatch.StartNew();
             using CancellationTokenSource source = new CancellationTokenSource(_maxWaitDuration);
             try
@@ -180,9 +188,18 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
             return string.IsNullOrWhiteSpace(details);
         }
 
-        internal bool TryExtractManifestAssets(string manifestFile, out List<Asset> assets, out string details)
+        /// <summary>
+        /// Parses the manifest files and extracts the assets into the given collection.
+        /// </summary>
+        /// <param name="manifestFile">Path to the file that will be parsed.</param>
+        /// <param name="assets">The collection that the new assets will be inserted into.</param>
+        /// <param name="details">Details of the encountered issue in case of an error.
+        /// The value is null or empty in the case of success.</param>
+        /// <returns></returns>
+        internal bool TryExtractManifestAssets(string manifestFile, ICollection<Asset> assets, out string details)
         {
             details = string.Empty;
+            Trace.WriteLine($"Loading the manifest file at path {manifestFile}");
 
             try
             {
@@ -190,59 +207,54 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 
                 if (buildManifest == null)
                 {
-                    assets = new List<Asset>();
                     details = "Failed to read/deserialize manifest file";
                     return false;
                 }
 
                 if (!buildManifest.Validate())
                 {
-                    assets = new List<Asset>();
-                    details = $"Validation of de-serialized {InsertionConstants.ManifestFile} file content failed.";
+                    details = $"Validation of de-serialized manifest file content has failed.";
                     return false;
                 }
 
                 if (buildManifest.Builds == null || buildManifest.Builds.Count == 0)
                 {
-                    assets = new List<Asset>();
                     details = $"Manifest file contains no builds.";
                     return false;
                 }
 
-                Trace.WriteLine($"De-serialized {buildManifest.Builds.Count} builds from {InsertionConstants.ManifestFile}.");
+                Trace.WriteLine($"De-serialized {buildManifest.Builds.Count} builds from the manifest file.");
 
-                ConcurrentDictionary<string, Asset> map = new ConcurrentDictionary<string, Asset>();
-                foreach (Build build in buildManifest.Builds.AsParallel())
+                int initialCollectionSize = assets.Count;
+
+                foreach (Build build in buildManifest.Builds)
                 {
-                    foreach (Asset asset in build.Assets.AsParallel())
+                    if (build.Assets == null)
+                    {
+                        Trace.WriteLine("Manifest file contains build with no assets inside. " +
+                            $"Skipping build with buildNumber={build.BuildNumber}.");
+                        continue;
+                    }
+
+                    foreach (Asset asset in build.Assets)
                     {
                         if (string.IsNullOrWhiteSpace(asset.Name))
                         {
-                            Trace.WriteLine($"Manifest file contains an asset with null/empty name: {InsertionConstants.ManifestFile}");
+                            Trace.WriteLine($"Manifest file contains an asset with null/empty name. The asset will be skipped.");
                             continue;
                         }
 
-                        if (!map.TryAdd(asset.Name, asset))
-                        {
-                            Trace.WriteLine($"Duplicate entry in the specified {InsertionConstants.ManifestFile} for asset {asset.Name}.");
-                        }
+                        assets.Add(asset);
                     }
                 }
 
-                assets = new List<Asset>(map.Count);
-                foreach (Asset value in map.Values.OrderBy(x => x.Name))
+                if (initialCollectionSize == assets.Count)
                 {
-                    assets.Add(value);
-                }
-
-                if (map.Count < 1)
-                {
-                    details = $"No assets in {InsertionConstants.ManifestFile}";
+                    details = $"No assets were found in the manifest file.";
                 }
             }
             catch (Exception e)
             {
-                assets = new List<Asset>();
                 details = e.Message;
             }
             return string.IsNullOrWhiteSpace(details);
@@ -253,7 +265,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
             string json = File.ReadAllText(manifestFile);
             if (string.IsNullOrWhiteSpace(json))
             {
-                Trace.WriteLine($"Failed to read {InsertionConstants.ManifestFile} JSon content from file {manifestFile}.");
+                Trace.WriteLine($"Failed to read JSon content from file {manifestFile}.");
                 return null;
             }
             try
@@ -262,7 +274,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
             }
             catch (Exception e)
             {
-                Trace.WriteLine($"Failed to de-serialize {InsertionConstants.ManifestFile} file content. Reason: {e.Message}.");
+                Trace.WriteLine($"Failed to de-serialize the content of the file at path: {manifestFile}.{Environment.NewLine} Reason: {e.Message}.");
                 return null;
             }
         }

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -189,13 +189,13 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
         }
 
         /// <summary>
-        /// Parses the manifest files and extracts the assets into the given collection.
+        /// Parses the manifest file and extracts the assets into the given collection.
         /// </summary>
         /// <param name="manifestFile">Path to the file that will be parsed.</param>
         /// <param name="assets">The collection that the new assets will be inserted into.</param>
         /// <param name="details">Details of the encountered issue in case of an error.
         /// The value is null or empty in the case of success.</param>
-        /// <returns></returns>
+        /// <returns>True if the operation succeeded without errors. False, otherwise.</returns>
         internal bool TryExtractManifestAssets(string manifestFile, ICollection<Asset> assets, out string details)
         {
             details = string.Empty;

--- a/src/InsertionsClient.Core/Common/Json/Serializer.cs
+++ b/src/InsertionsClient.Core/Common/Json/Serializer.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace Microsoft.DotNet.InsertionsClient.Common.Json
 {
     /// <summary>
-    /// Contains JSon serializing utilities.
+    /// Contains JSON serializing utilities.
     /// </summary>
     public static class Serializer
     {
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.InsertionsClient.Common.Json
         }
 
         /// <summary>
-        /// Deserializes a specified json to a targeted type <typeparamref name="TModel"/>.
+        /// Deserializes a specified JSON to a targeted type <typeparamref name="TModel"/>.
         /// </summary>
         /// <typeparam name="TModel">Targeted type.</typeparam>
         /// <param name="json">Specified json string.</param>
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.InsertionsClient.Common.Json
         }
 
         /// <summary>
-        /// Deserializes a specified json to a targeted type <typeparamref name="TModel"/>.
+        /// Deserializes a specified JSON to a targeted type <typeparamref name="TModel"/>.
         /// </summary>
         /// <typeparam name="TModel">Targeted type.</typeparam>
         /// <param name="json">Specified json string.</param>
@@ -55,11 +55,11 @@ namespace Microsoft.DotNet.InsertionsClient.Common.Json
         }
 
         /// <summary>
-        /// Serializes the specified object to a JSon string.
+        /// Serializes the specified object to a JSON string.
         /// </summary>
         /// <typeparam name="TModel">Type of object to serialize</typeparam>
         /// <param name="instance"></param>
-        /// <returns>Corresponding JSon string.</returns>
+        /// <returns>Corresponding JSON string.</returns>
         public static string Serialize<TModel>(TModel instance)
         {
             return Serialize(instance, new DataContractJsonSerializer(typeof(TModel), DataContractCustomTypes));

--- a/tests/InsertionsClient.Console.Test/InputParsingTests.cs
+++ b/tests/InsertionsClient.Console.Test/InputParsingTests.cs
@@ -60,7 +60,7 @@ namespace InsertionsClient.Console.Test
                     ignoredPackages,
                     null,
                     null);
-            
+
             Assert.IsFalse(results.UpdatedNuGets.Any(n => whitelistedPackages.All(pattern => !pattern.IsMatch(n.PackageId))), "Packages that shouldn't have been updated were updated.");
         }
 
@@ -98,7 +98,7 @@ namespace InsertionsClient.Console.Test
         {
             string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
             string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
-            
+
             Assert.IsTrue(File.Exists(manifestFile), "Manifest file that is required for the test was not found.");
 
             List<string> parsedPaths = InputLoading.LoadManifestPaths(manifestFile, out int invalidPathCount);
@@ -124,9 +124,9 @@ namespace InsertionsClient.Console.Test
         {
             string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
             string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
-            
+
             Assert.IsTrue(File.Exists(manifestFile), "Manifest file that is required for the test was not found.");
-            
+
             string nonexistentManifestFile = "A file that hopefully doesnt exist.44526223453856905547954332726542";
             string inputString = $"{nonexistentManifestFile};{manifestFile};; ;   ;";
 

--- a/tests/InsertionsClient.Console.Test/InputParsingTests.cs
+++ b/tests/InsertionsClient.Console.Test/InputParsingTests.cs
@@ -116,6 +116,42 @@ namespace InsertionsClient.Console.Test
         }
 
         /// <summary>
+        /// Tests whether <see cref="InputLoading.LoadManifestPaths(string, out int)"/> can load multiple valid manifest files.
+        /// </summary>
+        [TestMethod]
+        public void TestMultipleManifestPathLoading()
+        {
+            string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
+            string otherManifestFile = Path.GetTempFileName();
+
+            Assert.IsTrue(File.Exists(manifestFile), "Manifest file that is required for the test was not found.");
+            Assert.IsTrue(File.Exists(otherManifestFile), "Failed to create the temporary file that is required for the test.");
+
+            string inputString = $"{manifestFile};{otherManifestFile}";
+
+            List<string> parsedPaths = InputLoading.LoadManifestPaths(inputString, out int invalidPathCount);
+
+            Assert.IsNotNull(parsedPaths);
+            Assert.AreEqual(2, parsedPaths.Count, "Unexpected number of paths were extracted from the input string.");
+            Assert.AreEqual(0, invalidPathCount, "No invalid path was expected.");
+            Assert.IsTrue(File.Exists(parsedPaths[0]), $"Parsed path doesn't point to a valid file:{parsedPaths[0]}");
+            Assert.IsTrue(File.Exists(parsedPaths[1]), $"Parsed path doesn't point to a valid file:{parsedPaths[1]}");
+
+            FileInfo[] inputFiles = new []
+            {
+                new FileInfo(manifestFile),
+                new FileInfo(otherManifestFile)
+            };
+
+            List<FileInfo> parsedFiles = parsedPaths.Select(p => new FileInfo(p)).ToList();
+
+            // Path strings may be different, but they both should point to the same file.
+            bool pathsPointToSameFiles = inputFiles.All(p => parsedFiles.Any(i => i.FullName == p.FullName));
+            Assert.IsTrue(pathsPointToSameFiles, "Input files and the resulting files do not match.");
+        }
+
+        /// <summary>
         /// Tests whether <see cref="InputLoading.LoadManifestPaths(string, out int)"/> can load manifest files
         /// from an input string that contains a path to a non-existent file.
         /// </summary>

--- a/tests/InsertionsClient.Core.Test/ManifestTest.cs
+++ b/tests/InsertionsClient.Core.Test/ManifestTest.cs
@@ -48,10 +48,13 @@ namespace DefaultConfigClientTest
         [TestMethod]
         public void TestLoadNonJsonFile()
         {
+            InsertionApi insertionApi = new InsertionApi();
+            List<Asset> assets = new List<Asset>();
+            
             string fakeManifestPath = Path.Combine(Environment.CurrentDirectory, "fakeManifest.json");
             File.WriteAllText(fakeManifestPath, "some content that is not json");
-            InsertionApi insertionApi = new InsertionApi();
-            bool result = insertionApi.TryExtractManifestAssets(fakeManifestPath, out List<Asset> assets, out string error);
+
+            bool result = insertionApi.TryExtractManifestAssets(fakeManifestPath, assets, out string error);
             Assert.IsFalse(result);
             Assert.IsFalse(string.IsNullOrWhiteSpace(error));
             Assert.IsNotNull(assets);
@@ -87,7 +90,8 @@ namespace DefaultConfigClientTest
         private List<Asset> LoadManifestAssets()
         {
             InsertionApi insertionApi = new InsertionApi();
-            bool result = insertionApi.TryExtractManifestAssets(GetManifestFilePath(), out List<Asset> assets, out string error);
+            List<Asset> assets = new List<Asset>();
+            bool result = insertionApi.TryExtractManifestAssets(GetManifestFilePath(), assets, out string error);
             Assert.IsTrue(result, error);
             Assert.IsTrue(string.IsNullOrWhiteSpace(error), error);
             Assert.IsNotNull(assets);

--- a/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
+++ b/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
@@ -56,7 +56,7 @@ namespace InsertionsClient.Core.Test
 
             Assert.IsFalse(results.IgnoredNuGets.Any(), "No packages should have been ignored.");
         }
-        
+
         [TestMethod]
         public void TestIgnorelist()
         {
@@ -68,8 +68,8 @@ namespace InsertionsClient.Core.Test
             string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
             string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
             IEnumerable<Regex> whitelistedPackages = Enumerable.Empty<Regex>();
-            
-            ImmutableHashSet<string> ignoredPackages = ImmutableHashSet.Create( new string[]{
+
+            ImmutableHashSet<string> ignoredPackages = ImmutableHashSet.Create(new string[]{
                 @"^VS\.Redist\.Common\.NetCore\.AppHostPack\.x86_x64\.3\.1",
                 @"^VS\.Redist\.Common\.NetCore\.SharedFramework\.(x86|x64)\.[0-9]+\.[0-9]+$"
             });
@@ -84,7 +84,7 @@ namespace InsertionsClient.Core.Test
 
             // Ignore all modified files except for one
             Assert.IsFalse(results.UpdatedNuGets.Any(n => ignoredPackages.Contains(n.PackageId)), "A package that should have been ignored was updated.");
-            Assert.IsFalse(results.IgnoredNuGets.Any(n => !ignoredPackages.Contains(n)), "A package was ignored, but it shouldn't have been");            
+            Assert.IsFalse(results.IgnoredNuGets.Any(n => !ignoredPackages.Contains(n)), "A package was ignored, but it shouldn't have been");
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace InsertionsClient.Core.Test
             string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
             string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
             ImmutableHashSet<string> ignoredPackages = ImmutableHashSet<string>.Empty;
-            
+
             IEnumerable<Regex> whitelistedPackages = new Regex[]
             {
                 new Regex(@"VS\.Redist\.Common\.NetCore\.AppHostPack\.x86_x64\.3\.1"),


### PR DESCRIPTION
Delivers [#1217872](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1217872)

Changes in this PR add support for inserting multiple manifest.json files in a single run:
- `ManifestFile` input string can now represent a list of files separated with semicolon `;`.
- Paths defined in `ManifestFile` can also point to folders. In the case that a folder is provided, the manifest file is expected to be at location `<path to the folder>/manifest.json`.
- Updated manifest file processing logic which unsuccessfully attempted to parallelize the operation.
- Added tests for validating the `ManifestFile` input string.
- Updated the runtime help.
- Updated the README file.