### PR TITLE
Add the ability to selectively insert some of the builds in a manifest

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,11 +35,34 @@
     > _-ds:240_
 1. **-c:** Maximum concurrency of default.config version updates [**optional**].  Example:
     > _-c:10_
+1. **-bf:** Filter string to specify which builds from the manifest will be inserted.
+    
+    A simple build filter can be written as follows:
+    > _-bf:repo=.*core-setup_
+
+    Right side of the equals sign is a regular expression that should fully match the value of the build property that is given on the left side. Thus, this filter only inserts builds where the repo property ends with the word _core-setup_.
+
+    The previous example contained only one rule: `repo=.*core-setup`. If you want to specify multiple rules, you can separate them with a comma. Such as:
+    > _-bf:repo=.*core-setup,channel=release/3.1_
+
+    A set of rules separated by commas is called a "ruleset". For a build to pass the filter and get inserted, it should comply with **all** the rules within any ruleset.
+
+    A more complicated example of this could be:
+    > _-bf:repo=.*core-setup,channel=release/3.1;repo=.*,channel=release/5.0_
+
+    Which means that a build can be inserted if:
+    a. The repo name ends with core-setup and the channels list contains a channel with the name "release/3.1"
+    b. Or, the repo name can be anything, but one of the channel names should be "release/5.0"
+
+    As you can see, multiple rulesets can be specified using semicolons. A build only needs to comply with one of the rulesets to be inserted.
+    
+    For each rule, the word left of the `=` sign represents a build property. Build property can have the following values: `repo`, `commit`, `branch`,`buildNumber`. There is also a special property named `channel`. If `channel` is used, then the regular expression on the right side of the equals sign should match with any of the channels of the build.
 
 _Warnings_
 1. NO SPACES ALLOWED IN EITHER default.config OR manifest.json FILE PATHS
 1. NO SPACES ALLOWED IN props file search directory
 1. The default duration & concurrency values should suffice
+1. When using build filters with -bf switch, special characters in the regular expression should be properly escaped.
 
 ## Log
 * **InsertionsClient** creates a log detailing every step taken

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,17 +38,23 @@
 1. **-bf:** Filter string to specify which builds from the manifest will be inserted.
     
     A simple build filter can be written as follows:
-    > _-bf:repo=.*core-setup_
+    ```
+    -bf:repo=.*core-setup
+    ```
 
     Right side of the equals sign is a regular expression that should fully match the value of the build property that is given on the left side. Thus, this filter only inserts builds where the repo property ends with the word _core-setup_.
 
     The previous example contained only one rule: `repo=.*core-setup`. If you want to specify multiple rules, you can separate them with a comma. Such as:
-    > _-bf:repo=.*core-setup,channel=release/3.1_
+    ```
+    -bf:repo=.*core-setup,channel=release/3.1
+    ```
 
     A set of rules separated by commas is called a "ruleset". For a build to pass the filter and get inserted, it should comply with **all** the rules within any ruleset.
 
     A more complicated example of this could be:
-    > _-bf:repo=.*core-setup,channel=release/3.1;repo=.*,channel=release/5.0_
+    ```
+    -bf:repo=.*core-setup,channel=release/3.1;repo=.*,channel=release/5.0
+    ```
 
     Which means that a build can be inserted if:
     a. The repo name ends with core-setup and the channels list contains a channel with the name "release/3.1"

--- a/src/InsertionsClient.Console/ConsoleApp/BuildFilterFactory.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/BuildFilterFactory.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.DotNet.InsertionsClient.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
+{
+    internal static class BuildFilterFactory
+    {
+        /// <summary>
+        /// Given a filter string, generates a predicate that will decide
+        /// if the given build should pass or fail the filter.
+        /// </summary>
+        /// <param name="filterString">Input string that defines the filter.</param>
+        /// <param name="buildFilter">The created predicate.</param>
+        /// <returns>True if operation succeeded. False, otherwise.</returns>
+        public static bool TryCreateFromString(string filterString, out Predicate<Build>? buildFilter)
+        {
+            buildFilter = null;
+
+            if (string.IsNullOrWhiteSpace(filterString))
+            {
+                Trace.WriteLine("Failed to parse build filter. Provided input string is empty.");
+                return false;
+            }
+
+            try
+            {
+                // Root expression that the final predicate will be build on.
+                // Generated expressions from each ruleset will be combined with "Or" to construct this root expression.
+                Expression? rootExpression = null;
+
+                // Parameter for the build that we pass to the filter i.e. the parameter for the final predicate.
+                ParameterExpression buildParameter = Expression.Parameter(typeof(Build), "build");
+
+                string[] rulesets = filterString.Split(';');
+                foreach (string ruleset in rulesets)
+                {
+                    if (string.IsNullOrWhiteSpace(ruleset))
+                    {
+                        Trace.WriteLine("Ruleset cannot be empty. Please check your build filter.");
+                        return false;
+                    }
+
+                    // Create the expression that only checks this one ruleset.
+                    if(!TryCreateRulesetExpression(buildParameter, ruleset, out Expression? rulesetExpression))
+                    {
+                        Trace.WriteLine("Failed to create the expression for ruleset: " + ruleset);
+                        return false;
+                    }
+
+                    if (rootExpression == null)
+                    {
+                        // We haven't put any code into the root expression. This will be the first.
+                        rootExpression = rulesetExpression;
+                    }
+                    else
+                    {
+                        // Root expression already contains some code from the previous rulesets. Combine the new one with "Or".
+                        rootExpression = Expression.OrElse(rootExpression, rulesetExpression);
+                    }
+
+                }
+
+                Expression<Predicate<Build>> lambda = Expression.Lambda<Predicate<Build>>(rootExpression, false, buildParameter);
+                buildFilter = lambda.Compile();
+                return true;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine($"Parsing the build filter has failed unexpectedly. Exception: {e.ToString()}");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Creates an expression that checks weather a given Build successfully passes the filtering of the provided ruleset.
+        /// </summary>
+        /// <param name="buildParameter"></param>
+        /// <param name="ruleset"></param>
+        /// <param name="rulesetExpression"></param>
+        /// <returns></returns>
+        private static bool TryCreateRulesetExpression(ParameterExpression buildParameter, string ruleset, out Expression? rulesetExpression)
+        {
+            // Generated expressions from each rule in this ruleset will be combined with "And" to construct this ruleset expression.
+            rulesetExpression = null;
+            string[] rules = ruleset.Split(',');
+            foreach (string rule in rules)
+            {
+                if (string.IsNullOrWhiteSpace(rule))
+                {
+                    Trace.WriteLine($"An empty rule was found in ruleset {ruleset}. Please check your build filter.");
+                    return false;
+                }
+
+                string[] sides = rule.Split('=', 2);
+                if (sides.Length != 2 || sides[0].Length == 0 || sides[1].Length == 0)
+                {
+                    Trace.WriteLine($"Failed to parse the rule \"{rule}\": an equals sign should split the rule into two parts.");
+                    return false;
+                }
+
+                string propertyName = sides[0];
+                string regularExp = sides[1];
+                Regex? regex = null;
+
+                try
+                {
+                    regex = new Regex(regularExp, RegexOptions.Compiled);
+                }
+                catch (Exception e)
+                {
+                    Trace.WriteLine("Failed to parse the regular expression: " + regularExp + ": " + e.ToString());
+                    return false;
+                }
+
+                if (!TryGetBuildSelectorFromPropertyName(propertyName, regex, out Predicate<Build>? buildSelector)
+                    || buildSelector == null)
+                {
+                    Trace.WriteLine("Build selector couldn't be constructed from the given property name: " + propertyName);
+                    return false;
+                }
+
+                MethodCallExpression ruleExpression = Expression.Call(Expression.Constant(buildSelector.Target), buildSelector.Method, buildParameter);
+
+                if (rulesetExpression == null)
+                {
+                    // We haven't put any code into the expression of this ruleset. This will be the first.
+                    rulesetExpression = ruleExpression;
+                }
+                else
+                {
+                    // This ruleset already contains some code from the previous rules. Combine them with "And".
+                    rulesetExpression = Expression.AndAlso(rulesetExpression, ruleExpression);
+                }
+            }
+
+            Trace.WriteLine("Failed to generate an expression from the given ruleset: " + ruleset);
+            return rulesetExpression != null;
+        }
+
+        /// <summary>
+        /// Attempts to create a predicate with the given property name and the regular expression.
+        /// The predicate (1) takes a build as argument,
+        /// (2) accesses the property with the given name,
+        /// (3) tries to match it with the provided regular expression,
+        /// and (4) returns the result of the match.
+        /// </summary>
+        /// <param name="propertyName">Name of the property in the <see cref="Build"/> instance to be inputted to regex match.</param>
+        /// <param name="regex">Regular expression to test the property with.</param>
+        /// <param name="buildSelector">The generated predicate that can be used to check if a build succeeds matching its
+        /// property with the regular expression.</param>
+        /// <returns>True if creating a predicate was successful. False, otherwise.</returns>
+        private static bool TryGetBuildSelectorFromPropertyName(string propertyName, Regex regex, out Predicate<Build>? buildSelector)
+        {
+            switch (propertyName)
+            {
+                case "repo":
+                    buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Repository, regex);
+                    break;
+                case "commit":
+                    buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Commit, regex);
+                    break;
+                case "branch":
+                    buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Branch, regex);
+                    break;
+                case "buildNumber":
+                    buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.BuildNumber, regex);
+                    break;
+                case "channel":
+                    buildSelector = CreateBuildPredicateBasedOnChannel(regex);
+                    break;
+                default:
+                    buildSelector = null;
+                    Trace.WriteLine($"Given value \"{propertyName}\" does not correspond to a valid build property.");
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Creates a predicate that checks if the given property matches the provided regular expression.
+        /// </summary>
+        /// <param name="propertyGetter">Getter that will return a string property from a <see cref="Build"/></param>
+        /// <param name="regex">Regular expression to be used for evaluating the value of the property.</param>
+        /// <returns>The created predicate.</returns>
+        private static Predicate<Build> CreateBuildPredicateBasedOnStringProperty(Func<Build, string?> propertyGetter, Regex regex)
+        {
+            return (build) =>
+            {
+                string value = propertyGetter(build) ?? "";
+                Match? match = regex.Match(value);
+
+                if (match == null || !match.Success)
+                {
+                    return false;
+                }
+
+                return match.Length == (value?.Length ?? 0);
+            };
+        }
+
+        /// <summary>
+        /// Creates a predicate that checks if the provided regex matches any of the channels of the given build.
+        /// </summary>
+        /// <param name="regex">Regular expression to be used for evaluating the names of build channels.</param>
+        /// <returns>The created predicate.</returns>
+        private static Predicate<Build> CreateBuildPredicateBasedOnChannel(Regex regex)
+        {
+            return (build) =>
+            {
+                if (build.Channels == null || build.Channels.Count == 0)
+                {
+                    // We couldn't find a channel matching this regular expression
+                    return false;
+                }
+
+                foreach (Channel? channel in build.Channels)
+                {
+                    if (channel == null)
+                    {
+                        // Null channel cannot be considered a match.
+                        continue;
+                    }
+
+                    Match? match = regex.Match(channel.Name ?? "");
+
+                    if (match == null || !match.Success)
+                    {
+                        return false;
+                    }
+
+                    return match.Length == (channel.Name?.Length ?? 0);
+                }
+
+                return false;
+            };
+        }
+    }
+}

--- a/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
         /// <returns>A list of paths pointing to manifest files.</returns>
         internal static List<string> LoadManifestPaths(string manifestPaths, out int invalidPathCount)
         {
-            if(string.IsNullOrWhiteSpace(manifestPaths))
+            if (string.IsNullOrWhiteSpace(manifestPaths))
             {
                 invalidPathCount = 0;
                 return new List<string>();
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
 
             foreach (string path in paths)
             {
-                if(string.IsNullOrWhiteSpace(path))
+                if (string.IsNullOrWhiteSpace(path))
                 {
                     continue;
                 }
@@ -112,186 +112,6 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             }
 
             return results;
-        }
-    
-        /// <summary>
-        /// Parses the input string into a filter that will decide if a build should be inserted or not.
-        /// </summary>
-        /// <param name="filterString">Input string to be parsed.</param>
-        /// <param name="buildFilter">Filter generated from the input string.</param>
-        /// <returns>True if loading succeeded. False otherwise. </returns>
-        internal static bool LoadBuildFilter(string filterString, out Predicate<Build>? buildFilter)
-        {
-            buildFilter = null;
-
-            if(string.IsNullOrWhiteSpace(filterString))
-            {
-                Trace.WriteLine("Failed to parse build filter. Provided input string is empty.");
-                return false;
-            }
-
-            try
-            {
-                // Root expression that the final predicate will be build on.
-                // Generated expressions from each ruleset will be combined with "Or" to construct this root expression.
-                Expression? rootExpression = null;
-
-                // Parameter for the build that we pass to the filter i.e. the parameter for the final predicate.
-                ParameterExpression buildParameter = Expression.Parameter(typeof(Build), "build");
-
-                string[] rulesets = filterString.Split(';');
-                foreach(string ruleset in rulesets)
-                {
-                    if(string.IsNullOrWhiteSpace(ruleset))
-                    {
-                        Trace.WriteLine("Ruleset cannot be empty. Please check your build filter.");
-                        return false;
-                    }
-
-                    // Expression that only checks this one ruleset.
-                    // Generated expressions from each rule in this ruleset will be combined with "And" to construct this ruleset expression.
-                    Expression? rulesetExpression = null;
-
-                    string[] rules = ruleset.Split(',');
-                    foreach(string rule in rules)
-                    {
-                        if (string.IsNullOrWhiteSpace(rule))
-                        {
-                            Trace.WriteLine($"An empty rule was found in ruleset {ruleset}. Please check your build filter.");
-                            return false;
-                        }
-
-                        string[] sides = rule.Split('=', 2);
-                        if(sides.Length != 2)
-                        {
-                            Trace.WriteLine($"Failed to parse the rule \"{rule}\": an equals sign should split the rule into two parts.");
-                            return false;
-                        }
-
-                        string propertyName = sides[0];
-                        string regularExp = sides[1];
-
-                        Regex regex = new Regex(regularExp, RegexOptions.Compiled);
-                        Predicate<Build>? buildSelector = null;
-
-                        switch (propertyName)
-                        {
-                            case "repo":
-                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Repository, regex);
-                                break;
-                            case "commit":
-                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Commit, regex);
-                                break;
-                            case "branch":
-                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Branch, regex);
-                                break;
-                            case "buildNumber":
-                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.BuildNumber, regex);
-                                break;
-                            case "channel":
-                                buildSelector = CreateBuildPredicateBasedOnChannel(regex);
-                                break;
-                            default:
-                                Trace.WriteLine($"Given value \"{propertyName}\" does not correspond to a valid build property.");
-                                return false;
-                        }
-
-                        MethodCallExpression ruleExpression = Expression.Call(Expression.Constant(buildSelector.Target), buildSelector.Method, buildParameter);
-
-                        if(rulesetExpression == null)
-                        {
-                            // We haven't put any code into the expression of this ruleset. This will be the first.
-                            rulesetExpression = ruleExpression;
-                        }
-                        else
-                        {
-                            // This ruleset already contains some code from the previous rules. Combine them with "And".
-                            rulesetExpression = Expression.AndAlso(rulesetExpression, ruleExpression);
-                        }
-                    }
-
-                    if(rootExpression == null)
-                    {
-                        // We haven't put any code into the root expression. This will be the first.
-                        rootExpression = rulesetExpression;
-                    }
-                    else
-                    {
-                        // Root expression already contains some code from the previous rulesets. Combine the new one with "Or".
-                        rootExpression = Expression.OrElse(rootExpression, rulesetExpression);
-                    }
-
-                }
-
-                Expression<Predicate<Build>> lambda = Expression.Lambda<Predicate<Build>>(rootExpression, false, buildParameter);
-                buildFilter = lambda.Compile();
-                return true;
-            }
-            catch (Exception e)
-            {
-                Trace.WriteLine($"Parsing the build filter has failed unexpectedly. Exception: {e.ToString()}");
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Creates a predicate that checks if the given property matches the provided regular expression.
-        /// </summary>
-        /// <param name="propertyGetter">Getter that will return a string property from a <see cref="Build"/></param>
-        /// <param name="regex">Regular expression to be used for evaluating the value of the property.</param>
-        /// <returns>The created predicate.</returns>
-        internal static Predicate<Build> CreateBuildPredicateBasedOnStringProperty(Func<Build, string?> propertyGetter, Regex regex)
-        {
-            return (build) =>
-            {
-                string? value = propertyGetter(build);
-                Match? match = regex.Match(value);
-
-                if (match == null || !match.Success)
-                {
-                    return false;
-                }
-
-                return match.Length == (value?.Length ?? 0);
-            };
-        }
-
-        /// <summary>
-        /// Creates a predicate that checks if the provided regex matches any of the channels of the given build.
-        /// </summary>
-        /// <param name="regex">Regular expression to be used for evaluating the names of build channels.</param>
-        /// <returns>The created predicate.</returns>
-        internal static Predicate<Build> CreateBuildPredicateBasedOnChannel(Regex regex)
-        {
-            return (build) =>
-            {
-                if(build.Channels == null || build.Channels.Count == 0)
-                {
-                    // We couldn't find a channel matching this regular expression
-                    return false;
-                }
-
-                foreach(Channel? channel in build.Channels)
-                {
-                    if(channel == null)
-                    {
-                        // Null channel cannot be considered a match.
-                        continue;
-                    }
-
-                    Match? match = regex.Match(channel.Name);
-
-                    if (match == null || !match.Success)
-                    {
-                        return false;
-                    }
-
-                    return match.Length == (channel.Name?.Length ?? 0);
-                }
-
-                return false;
-            };
         }
     }
 }

--- a/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/InputLoading.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.DotNet.InsertionsClient.Api;
 using Microsoft.DotNet.InsertionsClient.Common.Constants;
+using Microsoft.DotNet.InsertionsClient.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
@@ -110,6 +112,186 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
             }
 
             return results;
+        }
+    
+        /// <summary>
+        /// Parses the input string into a filter that will decide if a build should be inserted or not.
+        /// </summary>
+        /// <param name="filterString">Input string to be parsed.</param>
+        /// <param name="buildFilter">Filter generated from the input string.</param>
+        /// <returns>True if loading succeeded. False otherwise. </returns>
+        internal static bool LoadBuildFilter(string filterString, out Predicate<Build>? buildFilter)
+        {
+            buildFilter = null;
+
+            if(string.IsNullOrWhiteSpace(filterString))
+            {
+                Trace.WriteLine("Failed to parse build filter. Provided input string is empty.");
+                return false;
+            }
+
+            try
+            {
+                // Root expression that the final predicate will be build on.
+                // Generated expressions from each ruleset will be combined with "Or" to construct this root expression.
+                Expression? rootExpression = null;
+
+                // Parameter for the build that we pass to the filter i.e. the parameter for the final predicate.
+                ParameterExpression buildParameter = Expression.Parameter(typeof(Build), "build");
+
+                string[] rulesets = filterString.Split(';');
+                foreach(string ruleset in rulesets)
+                {
+                    if(string.IsNullOrWhiteSpace(ruleset))
+                    {
+                        Trace.WriteLine("Ruleset cannot be empty. Please check your build filter.");
+                        return false;
+                    }
+
+                    // Expression that only checks this one ruleset.
+                    // Generated expressions from each rule in this ruleset will be combined with "And" to construct this ruleset expression.
+                    Expression? rulesetExpression = null;
+
+                    string[] rules = ruleset.Split(',');
+                    foreach(string rule in rules)
+                    {
+                        if (string.IsNullOrWhiteSpace(rule))
+                        {
+                            Trace.WriteLine($"An empty rule was found in ruleset {ruleset}. Please check your build filter.");
+                            return false;
+                        }
+
+                        string[] sides = rule.Split('=', 2);
+                        if(sides.Length != 2)
+                        {
+                            Trace.WriteLine($"Failed to parse the rule \"{rule}\": an equals sign should split the rule into two parts.");
+                            return false;
+                        }
+
+                        string propertyName = sides[0];
+                        string regularExp = sides[1];
+
+                        Regex regex = new Regex(regularExp, RegexOptions.Compiled);
+                        Predicate<Build>? buildSelector = null;
+
+                        switch (propertyName)
+                        {
+                            case "repo":
+                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Repository, regex);
+                                break;
+                            case "commit":
+                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Commit, regex);
+                                break;
+                            case "branch":
+                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.Branch, regex);
+                                break;
+                            case "buildNumber":
+                                buildSelector = CreateBuildPredicateBasedOnStringProperty(b => b.BuildNumber, regex);
+                                break;
+                            case "channel":
+                                buildSelector = CreateBuildPredicateBasedOnChannel(regex);
+                                break;
+                            default:
+                                Trace.WriteLine($"Given value \"{propertyName}\" does not correspond to a valid build property.");
+                                return false;
+                        }
+
+                        MethodCallExpression ruleExpression = Expression.Call(Expression.Constant(buildSelector.Target), buildSelector.Method, buildParameter);
+
+                        if(rulesetExpression == null)
+                        {
+                            // We haven't put any code into the expression of this ruleset. This will be the first.
+                            rulesetExpression = ruleExpression;
+                        }
+                        else
+                        {
+                            // This ruleset already contains some code from the previous rules. Combine them with "And".
+                            rulesetExpression = Expression.AndAlso(rulesetExpression, ruleExpression);
+                        }
+                    }
+
+                    if(rootExpression == null)
+                    {
+                        // We haven't put any code into the root expression. This will be the first.
+                        rootExpression = rulesetExpression;
+                    }
+                    else
+                    {
+                        // Root expression already contains some code from the previous rulesets. Combine the new one with "Or".
+                        rootExpression = Expression.OrElse(rootExpression, rulesetExpression);
+                    }
+
+                }
+
+                Expression<Predicate<Build>> lambda = Expression.Lambda<Predicate<Build>>(rootExpression, false, buildParameter);
+                buildFilter = lambda.Compile();
+                return true;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine($"Parsing the build filter has failed unexpectedly. Exception: {e.ToString()}");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Creates a predicate that checks if the given property matches the provided regular expression.
+        /// </summary>
+        /// <param name="propertyGetter">Getter that will return a string property from a <see cref="Build"/></param>
+        /// <param name="regex">Regular expression to be used for evaluating the value of the property.</param>
+        /// <returns>The created predicate.</returns>
+        internal static Predicate<Build> CreateBuildPredicateBasedOnStringProperty(Func<Build, string?> propertyGetter, Regex regex)
+        {
+            return (build) =>
+            {
+                string? value = propertyGetter(build);
+                Match? match = regex.Match(value);
+
+                if (match == null || !match.Success)
+                {
+                    return false;
+                }
+
+                return match.Length == (value?.Length ?? 0);
+            };
+        }
+
+        /// <summary>
+        /// Creates a predicate that checks if the provided regex matches any of the channels of the given build.
+        /// </summary>
+        /// <param name="regex">Regular expression to be used for evaluating the names of build channels.</param>
+        /// <returns>The created predicate.</returns>
+        internal static Predicate<Build> CreateBuildPredicateBasedOnChannel(Regex regex)
+        {
+            return (build) =>
+            {
+                if(build.Channels == null || build.Channels.Count == 0)
+                {
+                    // We couldn't find a channel matching this regular expression
+                    return false;
+                }
+
+                foreach(Channel? channel in build.Channels)
+                {
+                    if(channel == null)
+                    {
+                        // Null channel cannot be considered a match.
+                        continue;
+                    }
+
+                    Match? match = regex.Match(channel.Name);
+
+                    if (match == null || !match.Success)
+                    {
+                        return false;
+                    }
+
+                    return match.Length == (channel.Name?.Length ?? 0);
+                }
+
+                return false;
+            };
         }
     }
 }

--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.InsertionsClient.ConsoleApp
                 ignoredPackages = InsertionConstants.DefaultDevUxTeamPackages;
             }
 
-            if(!string.IsNullOrWhiteSpace(BuildFilterString) && !InputLoading.LoadBuildFilter(BuildFilterString, out buildFilter))
+            if(!string.IsNullOrWhiteSpace(BuildFilterString) && !BuildFilterFactory.TryCreateFromString(BuildFilterString, out buildFilter))
             {
                 ShowErrorHelpAndExit("Failed to parse build filters from input string: " + BuildFilterString);
             }

--- a/src/InsertionsClient.Core/Api/ApiExtensions.cs
+++ b/src/InsertionsClient.Core/Api/ApiExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.DotNet.InsertionsClient.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
@@ -20,7 +21,8 @@ namespace Microsoft.DotNet.InsertionsClient.Api
             IEnumerable<Regex> whitelistedPackages,
             ImmutableHashSet<string>? packagesToIgnore,
             string? accessToken,
-            string? propsFilesRootDirectory)
+            string? propsFilesRootDirectory,
+            Predicate<Build>? buildFilter)
         {
             return api.UpdateVersions(
                 new[] { manifestFile },
@@ -28,7 +30,8 @@ namespace Microsoft.DotNet.InsertionsClient.Api
                 whitelistedPackages,
                 packagesToIgnore,
                 accessToken,
-                propsFilesRootDirectory);
+                propsFilesRootDirectory,
+                buildFilter);
         }
     }
 }

--- a/src/InsertionsClient.Core/Api/IInsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApi.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.DotNet.InsertionsClient.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
@@ -24,6 +25,8 @@ namespace Microsoft.DotNet.InsertionsClient.Api
         /// <param name="packagesToIgnore"><see cref="HashSet{string}"/> of packages to ignore.</param>
         /// <param name="accessToken">Access token used when connecting to nuget feed.</param>
         /// <param name="propsFilesRootDirectory">Directory that will be searched for props files.</param>
+        /// <param name="buildFilter">Predicate to determine if a build should be included in the insertion process.
+        /// If null, all the builds will be included.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
         UpdateResults UpdateVersions(
             IEnumerable<string> manifestFiles,
@@ -31,6 +34,7 @@ namespace Microsoft.DotNet.InsertionsClient.Api
             IEnumerable<Regex> whitelistedPackages,
             ImmutableHashSet<string>? packagesToIgnore,
             string? accessToken,
-            string? propsFilesRootDirectory);
+            string? propsFilesRootDirectory,
+            Predicate<Build>? buildFilter);
     }
 }

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -227,11 +227,15 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 
                 Trace.WriteLine($"De-serialized {buildManifest.Builds.Count} builds from the manifest file.");
 
-                int initialCollectionSize = assets.Count;
+                if (!buildManifest.Builds.Any(b => b?.Assets != null && b.Assets.Any()))
+                {
+                    details = $"No assets were found in the manifest file.";
+                    return false;
+                }
 
                 foreach (Build build in buildManifest.Builds)
                 {
-                    if(buildFilter != null && !buildFilter(build))
+                    if (buildFilter != null && !buildFilter(build))
                     {
                         Trace.WriteLine($"The build with {nameof(build.BuildNumber)} {build.BuildNumber} was ignored by the filter. " +
                             "Assets from this build will not be used in the insertion process.");
@@ -255,11 +259,6 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
 
                         assets.Add(asset);
                     }
-                }
-
-                if (initialCollectionSize == assets.Count)
-                {
-                    details = $"No assets were found in the manifest file.";
                 }
             }
             catch (Exception e)

--- a/src/InsertionsClient.Core/Models/Build.cs
+++ b/src/InsertionsClient.Core/Models/Build.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -30,10 +31,16 @@ namespace Microsoft.DotNet.InsertionsClient.Models
         public string? Branch { get; set; }
 
         /// <summary>
+        /// A list of channels that this build should be pushed into.
+        /// </summary>
+        [DataMember(Name = "channels")]
+        public List<Channel>? Channels { get; set; }
+
+        /// <summary>
         /// Boxed timestamp for build creation.
         /// </summary>
         [DataMember(Name = "produced", IsRequired = true)]
-        public string? Produced { get; set; }
+        public DateTimeOffset? Produced { get; set; }
 
         /// <summary>
         /// Build number.

--- a/src/InsertionsClient.Core/Models/Build.cs
+++ b/src/InsertionsClient.Core/Models/Build.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.InsertionsClient.Models
         /// Boxed timestamp for build creation.
         /// </summary>
         [DataMember(Name = "produced", IsRequired = true)]
-        public DateTimeOffset? Produced { get; set; }
+        public string? Produced { get; set; }
 
         /// <summary>
         /// Build number.

--- a/src/InsertionsClient.Core/Models/Channel.cs
+++ b/src/InsertionsClient.Core/Models/Channel.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.DotNet.InsertionsClient.Models
+{
+    /// <summary>
+    /// Represents a channel that a build from a manifest.file json should be pushed into.
+    /// </summary>
+    public sealed class Channel
+    {
+        [DataMember(Name = "id", IsRequired = true)]
+        public int Id { get; set; }
+
+        [DataMember(Name = "name", IsRequired = true)]
+        public string? Name { get; set; }
+    }
+}

--- a/tests/InsertionsClient.Console.Test/BuildFilterFactoryTests.cs
+++ b/tests/InsertionsClient.Console.Test/BuildFilterFactoryTests.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.DotNet.InsertionsClient.ConsoleApp;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace InsertionsClient.Console.Test
+{
+    [TestClass]
+    public class BuildFilterFactoryTests
+    {
+        [TestMethod]
+        [DataRow(null, DisplayName = "null-string")]
+        [DataRow("", DisplayName = "empty-string")]
+        [DataRow(";")]
+        [DataRow(";;")]
+        [DataRow(",")]
+        [DataRow(",;,;")]
+        [DataRow("no-equals-sign-here", DisplayName = "missing-equals-sign")]
+        [DataRow("repo=", DisplayName = "missing-regex")]
+        [DataRow("repo=*(", DisplayName = "invalid-regex")]
+        [DataRow("=someregex", DisplayName = "missing-property")]
+        [DataRow("invalidprop=someregex", DisplayName = "invalid-property")]
+        public void TestInvalidRules(string input)
+        {
+            bool filterCreated = BuildFilterFactory.TryCreateFromString(input, out Predicate<Build>? buildFilter);
+            Assert.IsFalse(filterCreated, "Filter creation should have failed.");
+            Assert.IsNull(buildFilter, "Created filter should have been null.");
+        }
+
+        [TestMethod]
+        // 1 rule, 1 ruleset
+        [DataRow("repo=hey", "hey")]
+        [DataRow("repo=h.y", "hey")]
+        [DataRow("repo=^h.*s$", "here is a test& \\' cas^e with % symbols")]
+        [DataRow("repo=.*/installer", "www.github.com/dotnet/installer")]
+        // 2 rules, 1 ruleset
+        [DataRow("repo=.*/installer,channel=.*", "www.github.com/dotnet/installer", "channelName")]
+        [DataRow("repo=[M|m]ilkyway,channel=(ea|ti)ger", "Milkyway", "tiger")]
+        [DataRow("channel=(ea|ti)ger,repo=[M|m]ilkyway", "Milkyway", "tiger")]
+        [DataRow("repo=^a$,channel=c", "a", "c")]
+        // 2 rules, 2 rulesets
+        [DataRow("repo=.*/installer;repo=.*/aspnet-core", "www.github.com/dotnet/installer")]
+        [DataRow("repo=.*/installer;repo=.*/aspnet-core", "www.github.com/dotnet/aspnet-core")]
+        [DataRow("repo=.*/dotnet/.*;repo=.*/aspnet-core", "www.github.com/dotnet/aspnet-core")]
+        // 4 rules, 2 rulesets
+        [DataRow("repo=.*/installer,channel=release/5.0;repo=.*/aspnet-core,channel=release/3.1", "www.github.com/dotnet/installer", "release/5.0")]
+        [DataRow("repo=.*/installer,channel=release/5.0;repo=.*/aspnet-core,channel=release/3.1", "www.github.com/dotnet/aspnet-core", "release/3.1")]
+        // All valid property names
+        [DataRow("repo=.*,commit=.*,branch=.*,buildNumber=.*,channel=.*", "repo", "channel")]
+        public void TestMatchingBuilds(string inputFilter, string buildRepo, string? buildChannel = null)
+        {
+            bool filterCreated = BuildFilterFactory.TryCreateFromString(inputFilter, out Predicate<Build>? buildFilter);
+            Assert.IsTrue(filterCreated, "Filter creation should have succeeded.");
+            Assert.IsNotNull(buildFilter!, "Created filter shouldn't have been null.");
+
+            Build build = new Build()
+            {
+                Repository = buildRepo,
+                Channels = buildChannel == null ? null :
+                    new List<Channel>()
+                    {
+                        new Channel()
+                        {
+                            Id = 0,
+                            Name = buildChannel
+                        }
+                    }
+            };
+
+            bool didPassFilter = buildFilter!(build);
+            Assert.IsTrue(didPassFilter, "Filter shouldn't have returned false for this build.");
+        }
+
+        [TestMethod]
+        // 1 rule, 1 ruleset
+        [DataRow("repo=hey", "hky")]
+        [DataRow("repo=f.ll", "not a full match")]
+        [DataRow("repo=full.*$", "not a full match")]
+        // 2 rules, 1 ruleset
+        [DataRow("repo=.*/installer,channel=.*", "www.github.com/dotnet/aspnet-core", "channelName")]
+        [DataRow("repo=dotnet,channel=.*", "www.github.com/dotnet/aspnet-core", "channelName")]
+        [DataRow("repo=[M|m]ilkyway,channel=(ea|ti)ger", "Milkyhay", "timer")]
+        // 2 rules, 2 rulesets
+        [DataRow("repo=.*/installer;repo=.*/aspnet-core", "www.github.com/dotnet/core-setup")]
+        [DataRow("repo=.*/dotnet/.*;repo=.*/aspnet-core", "www.github.com/microsoft/msbuild")]
+        // 4 rules, 2 rulesets
+        [DataRow("repo=.*/installer,channel=release/5.0;repo=.*/aspnet-core,channel=release/3.1", "www.github.com/dotnet/installer", "release/3.1")]
+        [DataRow("repo=.*/installer,channel=release/5.0;repo=.*/aspnet-core,channel=release/3.1", "www.github.com/dotnet/aspnet-core", "release/5.0")]
+        public void TestExcludedBuilds(string inputFilter, string buildRepo, string? buildChannel = null)
+        {
+            bool filterCreated = BuildFilterFactory.TryCreateFromString(inputFilter, out Predicate<Build>? buildFilter);
+            Assert.IsTrue(filterCreated, "Filter creation should have succeeded.");
+            Assert.IsNotNull(buildFilter!, "Created filter shouldn't have been null.");
+
+            Build build = new Build()
+            {
+                Repository = buildRepo,
+                Channels = buildChannel == null ? null :
+                    new List<Channel>()
+                    {
+                        new Channel()
+                        {
+                            Id = 0,
+                            Name = buildChannel
+                        }
+                    }
+            };
+
+            bool didPassFilter = buildFilter!(build);
+            Assert.IsFalse(didPassFilter, "Filter shouldn't have returned true for this build.");
+        }
+    }
+}

--- a/tests/InsertionsClient.Console.Test/InputParsingTests.cs
+++ b/tests/InsertionsClient.Console.Test/InputParsingTests.cs
@@ -59,6 +59,7 @@ namespace InsertionsClient.Console.Test
                     whitelistedPackages,
                     ignoredPackages,
                     null,
+                    null,
                     null);
 
             Assert.IsFalse(results.UpdatedNuGets.Any(n => whitelistedPackages.All(pattern => !pattern.IsMatch(n.PackageId))), "Packages that shouldn't have been updated were updated.");
@@ -83,6 +84,7 @@ namespace InsertionsClient.Console.Test
                     defaultConfigFile,
                     whitelistedPackages,
                     ignoredPackages,
+                    null,
                     null,
                     null);
 

--- a/tests/InsertionsClient.Core.Test/BuildFilterTests.cs
+++ b/tests/InsertionsClient.Core.Test/BuildFilterTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.DotNet.InsertionsClient.Api;
+using Microsoft.DotNet.InsertionsClient.Api.Providers;
+using Microsoft.DotNet.InsertionsClient.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace InsertionsClient.Core.Test
+{
+    [TestClass]
+    public sealed class BuildFilterTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            // Everytime we run the api, default config is modified and saved. Keep a copy of the original default.config.
+            string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
+            File.Copy(defaultConfigFile, defaultConfigFile + ".copy", true);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Restore default.config from the backup we created
+            string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
+            File.Move(defaultConfigFile + ".copy", defaultConfigFile, true);
+        }
+
+        [TestMethod]
+        public void TestBuildRejections()
+        {
+            IInsertionApiFactory apiFactory = new InsertionApiFactory();
+            IInsertionApi api = apiFactory.Create(TimeSpan.FromSeconds(75), TimeSpan.FromSeconds(4));
+
+            UpdateResults results;
+            string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
+            string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
+            ImmutableHashSet<string> ignoredPackages = ImmutableHashSet<string>.Empty;
+            IEnumerable<Regex> allowedPackages = new List<Regex>();
+
+            results = api.UpdateVersions(
+                    manifestFile,
+                    defaultConfigFile,
+                    allowedPackages,
+                    null,
+                    null,
+                    null,
+                    build => false);
+
+            Assert.IsTrue(results.Outcome, "Insertion should have succeeded, but failed with error: " + results.OutcomeDetails);
+            Assert.IsTrue(results.UpdatedNuGets == null || !results.UpdatedNuGets.Any(), "No packages should have been updated.");
+
+            results = api.UpdateVersions(
+                    manifestFile,
+                    defaultConfigFile,
+                    allowedPackages,
+                    null,
+                    null,
+                    null,
+                    null);
+
+            Assert.IsTrue(results.Outcome, "Insertion should have succeeded, but failed with error: " + results.OutcomeDetails);
+            Assert.IsTrue(results.UpdatedNuGets != null && results.UpdatedNuGets.Any(), "Inconclusive test. This manifest didn't update any packages." +
+                " It is not possible to know if build filter worked or not.");
+        }
+    }
+}

--- a/tests/InsertionsClient.Core.Test/ManifestTest.cs
+++ b/tests/InsertionsClient.Core.Test/ManifestTest.cs
@@ -54,7 +54,7 @@ namespace DefaultConfigClientTest
             string fakeManifestPath = Path.Combine(Environment.CurrentDirectory, "fakeManifest.json");
             File.WriteAllText(fakeManifestPath, "some content that is not json");
 
-            bool result = insertionApi.TryExtractManifestAssets(fakeManifestPath, assets, out string error);
+            bool result = insertionApi.TryExtractManifestAssets(fakeManifestPath, null, assets, out string error);
             Assert.IsFalse(result);
             Assert.IsFalse(string.IsNullOrWhiteSpace(error));
             Assert.IsNotNull(assets);
@@ -91,7 +91,7 @@ namespace DefaultConfigClientTest
         {
             InsertionApi insertionApi = new InsertionApi();
             List<Asset> assets = new List<Asset>();
-            bool result = insertionApi.TryExtractManifestAssets(GetManifestFilePath(), assets, out string error);
+            bool result = insertionApi.TryExtractManifestAssets(GetManifestFilePath(), null, assets, out string error);
             Assert.IsTrue(result, error);
             Assert.IsTrue(string.IsNullOrWhiteSpace(error), error);
             Assert.IsNotNull(assets);

--- a/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
+++ b/tests/InsertionsClient.Core.Test/WhitelistAndIgnoreTests.cs
@@ -52,6 +52,7 @@ namespace InsertionsClient.Core.Test
                     whitelistedPackages,
                     ignoredPackages,
                     null,
+                    null,
                     null);
 
             Assert.IsFalse(results.IgnoredNuGets.Any(), "No packages should have been ignored.");
@@ -80,6 +81,7 @@ namespace InsertionsClient.Core.Test
                     whitelistedPackages,
                     ignoredPackages,
                     null,
+                    null,
                     null);
 
             // Ignore all modified files except for one
@@ -105,6 +107,7 @@ namespace InsertionsClient.Core.Test
                     defaultConfigFile,
                     whitelistedPackages,
                     ignoredPackages,
+                    null,
                     null,
                     null);
 
@@ -134,6 +137,7 @@ namespace InsertionsClient.Core.Test
                     defaultConfigFile,
                     whitelistedPackages,
                     ignoredPackages,
+                    null,
                     null,
                     null);
 


### PR DESCRIPTION
Delivers the first part of ["Eliminate the need to specify the target VS branch in insertion pipeline"](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1218731).

Depending on the target channels, builds in a single manifest may be inserted into multiple VS branches.
To allow this, we need to be able to select which builds from a manifest to insert.

This PR delivers the necessary changes so that:
- We can use a filter string to specify which builds to include in the insertion process.

This PR will be moved out of draft state once some tests are added.

