### PR TITLE
Fix: channels of manifests fail to deserialize

### DIFF
--- a/src/InsertionsClient.Core/Models/Channel.cs
+++ b/src/InsertionsClient.Core/Models/Channel.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DotNet.InsertionsClient.Models
     /// <summary>
     /// Represents a channel that a build from a manifest.file json should be pushed into.
     /// </summary>
+    [DataContract(Name = "channel")]
     public sealed class Channel
     {
         [DataMember(Name = "id", IsRequired = true)]


### PR DESCRIPTION
Fixes [ADO#1262285](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1262285).

Build channels were not properly being deserialized from json file. This PR fixes the issue.