### PR TITLE
Log if version is already up-to-date

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,9 @@ trigger:
 pr:
 - main
 
+pool:
+    vmImage: ubuntu-latest
+
 steps:
 - task: DotNetCoreCLI@2
   inputs:

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -342,7 +342,11 @@ namespace Microsoft.DotNet.InsertionsClient.Api.Providers
             if (oldVersion < semanticVersion)
             {
                 results.AddPackage(new PackageUpdateResult(packageId, oldVersion.ToFullString(), asset.Version!));
-                Trace.WriteLine($"Package {packageId} was updated to version {asset.Version}");
+                Trace.WriteLine($"Package '{packageId}' was updated to version {asset.Version}");
+            }
+            else
+            {
+                Trace.WriteLine($"Version number of package '{packageId}' was not changed since the current version ({oldVersion?.ToFullString()}) is more up-to-date than the given version ({asset.Version}).");
             }
         }
 


### PR DESCRIPTION
If the version of a package in `manifest.json` file is older than the package version in VS repo `default.config` file, insertions client silently continues by skipping the package. This makes it difficult to understand what happened if the created PR contains no changes.

This PR adds logs to this case to make it easier to investigate this case by looking at the logs in AzDO. 