### PR TITLE
Fix incorrect WarningsAsErrors elements

### DIFF
--- a/src/InsertionsClient.Console/InsertionsClient.Console.csproj
+++ b/src/InsertionsClient.Console/InsertionsClient.Console.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.DotNet.InsertionsClient</RootNamespace>
     <AssemblyName>Microsoft.DotNet.InsertionsClient.Console</AssemblyName>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors), nullable</WarningsAsErrors>
     
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>InsertionsClient</ToolCommandName>

--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Microsoft.DotNet.InsertionsClient</RootNamespace>
     <AssemblyName>Microsoft.DotNet.InsertionsClient.Core</AssemblyName>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors), nullable</WarningsAsErrors>
     
     <Authors>Microsoft, DotNet</Authors>
     <Company>Microsoft</Company>

--- a/tests/InsertionsClient.Console.Test/InsertionsClient.Console.Test.csproj
+++ b/tests/InsertionsClient.Console.Test/InsertionsClient.Console.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningsAsErrors>NU1605, nullable</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors), NU1605, nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using the below syntax performs a complete replacement of warning codes which should be treated as errors.

```xml
<WarningsAsErrors>aaaaa;bbbbb;ccccc;...</WarningsAsErrors>
```

Instead, the following syntax should be used, which inherits the base list coming from the SDK and augments the list with your desired warning codes.

```xml
<WarningsAsErrors>$(WarningsAsErrors);aaaaa;bbbbb;ccccc;...</WarningsAsErrors>
```

> Exception: If you're intentionally trying to suppress the SDK's base list, please ignore this rule.