### PR TITLE
Update Nuget.Versioning version

### DIFF
--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" Version="5.9.3" />
-    <PackageReference Include="NuGet.Versioning" Version="5.8.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.9.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Current version of this package causes a downgrade as Nuget.Protocol requires a higher version than what we explicitly specified.

Updating the project to have the version number match in both dependencies.