### PR TITLE
Update Nuget.Protocol and Microsoft.NET.Test.Sdk versions

### DIFF
--- a/src/InsertionsClient.Core/InsertionsClient.Core.csproj
+++ b/src/InsertionsClient.Core/InsertionsClient.Core.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="5.9.3" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.3" />
+    <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
+    <PackageReference Include="NuGet.Versioning" Version="6.3.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/InsertionsClient.Console.Test/InsertionsClient.Console.Test.csproj
+++ b/tests/InsertionsClient.Console.Test/InsertionsClient.Console.Test.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/tests/InsertionsClient.Core.Test/InsertionsClient.Core.Test.csproj
+++ b/tests/InsertionsClient.Core.Test/InsertionsClient.Core.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0">


### PR DESCRIPTION
Bumping dependencies to stop transitively pulling older Newtonsoft.Json